### PR TITLE
Vector structs -> unions for index-based access

### DIFF
--- a/dmath.h
+++ b/dmath.h
@@ -57,16 +57,12 @@ typedef double r64;
 
 /* 2D Vector */
 
-typedef struct v2d
+typedef union v2d
 {
+	struct { r64 x, y; };
+	struct { r64 d[2]; };
 #ifndef DMATH_NO_SSE
-	union
-	{
-		struct { r64 x, y; };
-		__m128d v;
-	};
-#else
-	r64 x, y;
+	struct { __m128d v; };
 #endif
 } v2d;
 

--- a/fmath.h
+++ b/fmath.h
@@ -58,9 +58,10 @@ typedef float r32;
 
 /* 2D Vector */
 
-typedef struct v2f
+typedef union v2f
 {
-	r32 x, y;
+	struct { r32 x, y; };
+	struct { r32 d[2]; };
 } v2f;
 
 FMGDECL const v2f g_v2f_x_axis;
@@ -109,9 +110,10 @@ FMDEF v2f  v2f_midpoint(v2f v0, v2f v1);
 
 /* 3D Vector */
 
-typedef struct v3f
+typedef union v3f
 {
-	r32 x, y, z;
+	struct { r32 x, y, z; };
+	struct { r32 d[3]; };
 } v3f;
 
 FMGDECL const v3f g_v3f_x_axis;

--- a/imath.h
+++ b/imath.h
@@ -44,13 +44,10 @@ typedef int s32;
 
 /* 2D Vector */
 
-typedef struct v2i
+typedef union v2i
 {
-	union
-	{
-		struct { s32 x, y; };
-		struct { s32 d[2]; };
-	};
+	struct { s32 x, y; };
+	struct { s32 d[2]; };
 } v2i;
 
 IMGDECL const v2i g_v2i_zero;


### PR DESCRIPTION
Can be accessed as vector.d[i] to make looping over compenents easier.